### PR TITLE
Add DbContext/DbSet Add and AddRange benchmarks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ FakesAssemblies/
 log-*.txt
 
 docs/_build/
+/benchmarks/EFCore.Cassandra.Benchmarks/BenchmarkDotNet.Artifacts/results

--- a/EFCore.Cassandra.sln
+++ b/EFCore.Cassandra.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30626.31
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "01. Core Layer", "01. Core Layer", "{4920F8DE-E217-452A-865A-E47DAC924B5F}"
 EndProject
@@ -19,6 +19,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Cassandra.Tests", "tests\EFCore.Cassandra.Tests\EFCore.Cassandra.Tests.csproj", "{BE0A2541-1253-4917-A070-4BB8F71F4704}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Cassandra.Samples", "samples\EFCore.Cassandra.Samples\EFCore.Cassandra.Samples.csproj", "{84CB9B7A-BDCF-4AF6-8C02-80405EB54C93}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "04. Benchmark Layer", "04. Benchmark Layer", "{A7EDC374-125D-41ED-868F-0D7829B45F2A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.Cassandra.Benchmarks", "benchmarks\EFCore.Cassandra.Benchmarks\EFCore.Cassandra.Benchmarks.csproj", "{30011B0A-1304-47B5-8E19-3D37779FE083}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,6 +42,10 @@ Global
 		{84CB9B7A-BDCF-4AF6-8C02-80405EB54C93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84CB9B7A-BDCF-4AF6-8C02-80405EB54C93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84CB9B7A-BDCF-4AF6-8C02-80405EB54C93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30011B0A-1304-47B5-8E19-3D37779FE083}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30011B0A-1304-47B5-8E19-3D37779FE083}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30011B0A-1304-47B5-8E19-3D37779FE083}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30011B0A-1304-47B5-8E19-3D37779FE083}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +54,7 @@ Global
 		{2D74D363-66B9-424B-BB34-468BEF0A2F07} = {4920F8DE-E217-452A-865A-E47DAC924B5F}
 		{BE0A2541-1253-4917-A070-4BB8F71F4704} = {BCAC9560-F9EC-4C11-A0E2-D3CAC0759519}
 		{84CB9B7A-BDCF-4AF6-8C02-80405EB54C93} = {D43C01D1-8661-4A06-B3D8-5CD1A9AC1DB3}
+		{30011B0A-1304-47B5-8E19-3D37779FE083} = {A7EDC374-125D-41ED-868F-0D7829B45F2A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13BDB38B-AFCC-4B2C-B0F9-404FB6249216}

--- a/benchmarks/EFCore.Cassandra.Benchmarks/CassandraBenchmarkConfig.cs
+++ b/benchmarks/EFCore.Cassandra.Benchmarks/CassandraBenchmarkConfig.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+
+namespace EFCore.Cassandra.Benchmarks
+{
+  [Config(typeof(CassandraBenchmarkConfig))]
+  public class CassandraBenchmarkConfig : ManualConfig
+  {
+    public CassandraBenchmarkConfig()
+    {
+      AddJob(
+        Job.Default
+          .WithPlatform(Platform.X64)
+          .WithJit(Jit.RyuJit)
+          .WithRuntime(CoreRuntime.Core31)
+          .WithWarmupCount(1)
+          .WithIterationCount(3)
+          .WithId("Cassandra benchmark config"));
+
+      AddDiagnoser(MemoryDiagnoser.Default);
+    }
+  }
+}

--- a/benchmarks/EFCore.Cassandra.Benchmarks/EFCore.Cassandra.Benchmarks.csproj
+++ b/benchmarks/EFCore.Cassandra.Benchmarks/EFCore.Cassandra.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\EFCore.Cassandra.Samples\EFCore.Cassandra.Samples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/EFCore.Cassandra.Benchmarks/InsertFixture.cs
+++ b/benchmarks/EFCore.Cassandra.Benchmarks/InsertFixture.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using BenchmarkDotNet.Attributes;
+using Cassandra;
+using EFCore.Cassandra.Samples;
+using EFCore.Cassandra.Samples.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCore.Cassandra.Benchmarks
+{
+  [Config(typeof(CassandraBenchmarkConfig))]
+  public class InsertFixture : IDisposable
+  {
+    private readonly FakeDbContext _dbContextSut;
+
+    private Applicant[] _data;
+
+    [ParamsSource(nameof(IterationsParams))]
+    public int Iterations;
+
+    public InsertFixture()
+    {
+      _dbContextSut = new FakeDbContext();
+    }
+
+    public IEnumerable<int> IterationsParams => new[]
+    {
+      1_000,
+      10_000,
+    };
+        
+    public void Dispose()
+    {
+      _dbContextSut.Dispose();
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+      _dbContextSut.Database.Migrate();
+
+      _data = Enumerable.Range(1, Iterations).Select(_ => BuildFullApplicant()).ToArray();
+    }
+
+    [Benchmark]
+    public void Add_SaveChanges()
+    {
+      foreach (var applicant in _data)
+      {
+        _dbContextSut.Applicants.Add(applicant);
+      }
+
+      _dbContextSut.SaveChanges();
+    }
+
+    [Benchmark]
+    public void AddRange_SaveChanges()
+    {
+      _dbContextSut.Applicants.AddRange(_data);
+      _dbContextSut.SaveChanges();
+    }
+
+    private static Applicant BuildFullApplicant()
+    {
+      var timeUuid = TimeUuid.NewId();
+      return new Applicant
+      {
+        Id = Guid.NewGuid(),
+        ApplicantId = Guid.NewGuid(),
+        Order = 0,
+        Lst = new List<string>
+        {
+          "1",
+          "2"
+        },
+        LstInt = new List<int>
+        {
+          1, 2, 3
+        },
+        Dic = new Dictionary<string, string>
+        {
+          {"coucou", "coucou"}
+        },
+        LastName = "lastname",
+        BigInteger = 10,
+        Bool = false,
+        Decimal = 1,
+        Double = 2,
+        Integer = 3,
+        Float = 4,
+        Sbyte = 0,
+        TimeUuid = timeUuid,
+        DateTimeOffset = DateTimeOffset.Now,
+        Long = 22,
+        SmallInt = 11,
+        Blob = new byte[] {1, 2},
+        LocalDate = new LocalDate(2019, 10, 2),
+        Ip = IPAddress.Loopback,
+        LocalTime = new LocalTime(2, 3, 4, 5),
+        Address = new ApplicantAddress
+        {
+          City = "Brussels",
+          StreetNumber = 100
+        }
+      };
+    }
+  }
+}

--- a/benchmarks/EFCore.Cassandra.Benchmarks/Program.cs
+++ b/benchmarks/EFCore.Cassandra.Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+﻿namespace EFCore.Cassandra.Benchmarks
+{
+  internal class Program
+  {
+    private static void Main(string[] args)
+    {
+#if DEBUG
+      var benchmarks = new InsertFixture();
+      benchmarks.Add_SaveChanges();
+      benchmarks.AddRange_SaveChanges();
+#else
+      var summary = BenchmarkRunner.Run<InsertFixture>();
+#endif
+    }
+  }
+}

--- a/benchmarks/EFCore.Cassandra.Benchmarks/README.md
+++ b/benchmarks/EFCore.Cassandra.Benchmarks/README.md
@@ -1,0 +1,24 @@
+﻿# Benchmark results
+
+To run benchmarks, use `dotnet run -c release`
+
+## Insert
+Cassandra was hosted in Docker on the same machine.
+
+```
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+AMD Ryzen 5 2600X, 1 CPU, 12 logical and 6 physical cores
+.NET Core SDK=5.0.100-rc.2.20479.15
+  [Host]                     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+  Cassandra benchmark config : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+
+Job=Cassandra benchmark config  Jit=RyuJit  Platform=X64
+Runtime=.NET Core 3.1  IterationCount=3  WarmupCount=1
+
+|               Method | Iterations |     Mean |    Error |   StdDev |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
+|--------------------- |----------- |---------:|---------:|---------:|------------:|-----------:|----------:|----------:|
+|      Add_SaveChanges |       1000 |  2.875 s | 2.0218 s | 0.1108 s |  15000.0000 |  1000.0000 |         - |  71.93 MB |
+| AddRange_SaveChanges |       1000 |  2.730 s | 0.3026 s | 0.0166 s |  16000.0000 |  1000.0000 |         - |  71.91 MB |
+|      Add_SaveChanges |      10000 | 27.420 s | 2.6518 s | 0.1454 s | 170000.0000 | 50000.0000 | 2000.0000 | 718.05 MB |
+| AddRange_SaveChanges |      10000 | 27.291 s | 0.3736 s | 0.0205 s | 170000.0000 | 52000.0000 | 2000.0000 | 717.85 MB |
+```


### PR DESCRIPTION
I wanted to see how the use of EF Core impacts performance. Using directly the CassandraCSharpDriver is about 100 times faster on insert operation.  Is there something wrong with my approach?