### PR TITLE
Extend benchmarks to demonstrate scalability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ FakesAssemblies/
 log-*.txt
 
 docs/_build/
+/src/EFCore.Cassandra.Benchmarks/BenchmarkDotNet.Artifacts/results

--- a/src/EFCore.Cassandra.Benchmarks/BatchedInsertData.cs
+++ b/src/EFCore.Cassandra.Benchmarks/BatchedInsertData.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using EFCore.Cassandra.Benchmarks.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCore.Cassandra.Benchmarks
+{
+    [Config(typeof(CassandraBenchmarkConfig))]
+    public class BatchedInsertData : IDisposable
+    {
+        private readonly FakeDbContext _dbContext;
+        private Applicant[][] _applicants;
+
+        public BatchedInsertData()
+        {
+            _dbContext = new FakeDbContext();
+        }
+
+        [ParamsSource(nameof(IterationsSource))]
+        public int Iterations { get; set; } = 1000;
+
+        public IEnumerable<int> IterationsSource => new[] {1, 10, 100};
+
+        [ParamsSource(nameof(BatchSizeSource))]
+        public int BatchSize { get; set; } = 10;
+
+        public IEnumerable<int> BatchSizeSource => new[] {10, 100};
+
+        public void Dispose()
+        {
+            _dbContext.Dispose();
+        }
+
+        [GlobalSetup]
+        public void SetupFixture()
+        {
+            _applicants = Enumerable.Range(0, Iterations).Select(_ => BuildApplicants()).ToArray();
+        }
+
+
+        [Benchmark]
+        public async Task BatchedInsertApplicantsAsync()
+        {
+            var a = Enumerable.Range(0, Iterations)
+                .Select(i => _dbContext.BulkInsertAsync(_applicants[i].ToList()));
+
+            await Task.WhenAll(a);
+        }
+
+
+        private Applicant[] BuildApplicants()
+        {
+            return Enumerable.Range(0, BatchSize).Select(_ => BuildApplicant()).ToArray();
+        }
+
+        private static Applicant BuildApplicant() =>
+            new Applicant
+            {
+                Id = Guid.NewGuid(),
+                Order = 0,
+                Dic = new Dictionary<string, string>(),
+                Lst = new List<string>(),
+                LstInt = new List<int>()
+            };
+    }
+}

--- a/src/EFCore.Cassandra.Benchmarks/CassandraBenchmarkConfig.cs
+++ b/src/EFCore.Cassandra.Benchmarks/CassandraBenchmarkConfig.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+
+namespace EFCore.Cassandra.Benchmarks
+{
+  [Config(typeof(CassandraBenchmarkConfig))]
+  public class CassandraBenchmarkConfig : ManualConfig
+  {
+    public CassandraBenchmarkConfig()
+    {
+      AddJob(
+        Job.Default
+          .WithPlatform(Platform.X64)
+          .WithJit(Jit.RyuJit)
+          .WithRuntime(CoreRuntime.Core31)
+          .WithWarmupCount(1)
+          .WithIterationCount(3)
+          .WithId("Cassandra benchmark config"));
+
+      AddDiagnoser(MemoryDiagnoser.Default);
+    }
+  }
+}

--- a/src/EFCore.Cassandra.Benchmarks/InsertData.cs
+++ b/src/EFCore.Cassandra.Benchmarks/InsertData.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 namespace EFCore.Cassandra.Benchmarks
 {
+    [Config(typeof(CassandraBenchmarkConfig))]
     public class InsertData : IDisposable
     {
         private readonly FakeDbContext _dbContext;

--- a/src/EFCore.Cassandra.Benchmarks/Program.cs
+++ b/src/EFCore.Cassandra.Benchmarks/Program.cs
@@ -10,6 +10,7 @@ namespace EFCore.Cassandra.Benchmarks
         private static async Task Main(string[] args)
         {
             BenchmarkRunner.Run<InsertData>();
+            BenchmarkRunner.Run<BatchedInsertData>();
         }
     }
 }

--- a/src/EFCore.Cassandra.Benchmarks/Program.cs
+++ b/src/EFCore.Cassandra.Benchmarks/Program.cs
@@ -9,8 +9,18 @@ namespace EFCore.Cassandra.Benchmarks
     {
         private static async Task Main(string[] args)
         {
+#if DEBUG
+            var insertData = new InsertData();
+            insertData.AddApplicants();
+            insertData.BulkInsertApplicants();
+            insertData.AddRangeApplicants();
+
+            var batchedInsertData = new BatchedInsertData();
+            await batchedInsertData.BatchedInsertApplicantsAsync();
+#else
             BenchmarkRunner.Run<InsertData>();
             BenchmarkRunner.Run<BatchedInsertData>();
+#endif
         }
     }
 }

--- a/src/EFCore.Cassandra.Benchmarks/README.md
+++ b/src/EFCore.Cassandra.Benchmarks/README.md
@@ -1,0 +1,43 @@
+﻿# Benchmark results
+
+## InsertData
+
+```
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+AMD Ryzen 5 2600X, 1 CPU, 12 logical and 6 physical cores
+.NET Core SDK=5.0.100-rc.2.20479.15
+  [Host]                     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+  Cassandra benchmark config : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+
+Job=Cassandra benchmark config  Jit=RyuJit  Platform=X64
+Runtime=.NET Core 3.1  IterationCount=3  WarmupCount=1
+
+|               Method |     Mean |     Error |   StdDev | Gen 0 | Gen 1 | Gen 2 |  Allocated |
+|--------------------- |---------:|----------:|---------:|------:|------:|------:|-----------:|
+|        AddApplicants | 64.82 ms | 53.485 ms | 2.932 ms |     - |     - |     - | 1632.24 KB |
+|   AddRangeApplicants | 65.13 ms | 46.057 ms | 2.525 ms |     - |     - |     - | 1634.05 KB |
+| BulkInsertApplicants | 29.42 ms |  5.828 ms | 0.319 ms |     - |     - |     - |  556.35 KB |
+```
+
+
+# BarchedInsertData
+
+```
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+AMD Ryzen 5 2600X, 1 CPU, 12 logical and 6 physical cores
+.NET Core SDK=5.0.100-rc.2.20479.15
+  [Host]                     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+  Cassandra benchmark config : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+
+Job=Cassandra benchmark config  Jit=RyuJit  Platform=X64
+Runtime=.NET Core 3.1  IterationCount=3  WarmupCount=1
+
+|                       Method | Iterations | BatchSize |         Mean |      Error |    StdDev |      Gen 0 |     Gen 1 | Gen 2 |    Allocated |
+|----------------------------- |----------- |---------- |-------------:|-----------:|----------:|-----------:|----------:|------:|-------------:|
+| BatchedInsertApplicantsAsync |          1 |        10 |     17.98 ms |   8.822 ms |  0.484 ms |          - |         - |     - |    282.18 KB |
+| BatchedInsertApplicantsAsync |          1 |       100 |    134.66 ms | 133.414 ms |  7.313 ms |          - |         - |     - |   2731.55 KB |
+| BatchedInsertApplicantsAsync |         10 |        10 |    138.43 ms |  78.095 ms |  4.281 ms |          - |         - |     - |   2795.91 KB |
+| BatchedInsertApplicantsAsync |         10 |       100 |  1,186.80 ms |  99.393 ms |  5.448 ms |  5000.0000 | 1000.0000 |     - |  25882.28 KB |
+| BatchedInsertApplicantsAsync |        100 |        10 |  1,227.66 ms |  75.714 ms |  4.150 ms |  6000.0000 | 1000.0000 |     - |  26384.59 KB |
+| BatchedInsertApplicantsAsync |        100 |       100 | 11,802.71 ms | 582.269 ms | 31.916 ms | 63000.0000 | 2000.0000 |     - | 258819.98 KB |
+```


### PR DESCRIPTION
To show scaling, this PR adds the `BatchedInsertData`  benchmark.

Due to the instability of communication between the benchmark and Cassandra, the `CassandraBenchmarkConfig` eliminates unnecessary benchmark trials.

For simple benchmark debugging, I also add ifdef into the Main method. Benchmark should always run in the release configuration, so there is no harm to it. 