### PR TITLE
Fix column names

### DIFF
--- a/src/EFCore.Cassandra/Extensions/CassandraEntityTypeExtensions.cs
+++ b/src/EFCore.Cassandra/Extensions/CassandraEntityTypeExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Cassandra.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -17,7 +18,8 @@ namespace Microsoft.EntityFrameworkCore
                 return new string[0];
             }
 
-            return (IEnumerable<string>)result.Value;
+            StoreObjectIdentifier identifier = new StoreObjectIdentifier();
+            return model.GetProperties().Where(p => p.Name == result.Value.ToString()).Select(p => p.GetColumnName(in identifier));
         }
 
         public static IEnumerable<string> GetStaticColumns(this IEntityType model)
@@ -28,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore
                 return new string[0];
             }
 
-            return (IEnumerable<string>)result.Value;
+            StoreObjectIdentifier identifier = new StoreObjectIdentifier();
+            return model.GetProperties().Where(p => p.Name == result.Value.ToString()).Select(p => p.GetColumnName(in identifier));
         }
 
         public static IEnumerable<CassandraClusteringOrderByOption> GetClusteringOrderByOptions(this IEntityType model)


### PR DESCRIPTION
If you use case-sensitive columns and create a key or cluster column, the cql code generated won't use the right the column names.

**Example**:
` 
        protected override void OnModelCreating(ModelBuilder modelBuilder)
        {
            // ...
            modelBuilder.Entity<AppUserInformation>().ToTable("user").HasKey(_ => _.Email);
            modelBuilder.Entity<AppUserInformation>().Property(p => p.Id).HasColumnName("id");
            modelBuilder.Entity<AppUserInformation>().Property(p => p.Email).HasColumnName("email");
            // ...
            modelBuilder.Entity<AppUserInformation>().ForCassandraSetClusterColumns(_ => _.Email);
            // ...
        }

`
The column 'Email' (instead of 'email') will be used in cql statements.
Maybe the changes I made could fix this.